### PR TITLE
feat(delete-event): implement delete event functionality

### DIFF
--- a/src/modules/event/controllers/event.controller.ts
+++ b/src/modules/event/controllers/event.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Body, Get, Query, UseGuards, Req, UnauthorizedException, UsePipes, ValidationPipe, Param, ParseIntPipe, InternalServerErrorException, Put } from '@nestjs/common';
+import { Controller, Post, Body, Get, Query, UseGuards, Req, UnauthorizedException, UsePipes, ValidationPipe, Param, ParseIntPipe, InternalServerErrorException, Put, Delete } from '@nestjs/common';
 import { JwtUserGuard } from 'src/modules/auth/guards/jwt-user.guard';
 import { EventService } from '../services/event.service';
 import { CreateEventDto } from '../dtos/create-event.dto';
@@ -61,7 +61,25 @@ export class EventController {
       await this.eventService.updateEvent(id, userId, updateEventDto);
       return new ResponseDto(null, 'Event updated successfully');
     } catch (error) {
+      if (error instanceof UnauthorizedException) {
+        throw error;
+      }
       throw new InternalServerErrorException('Error updating event')
+    }
+  }
+
+  @Delete('/:id')
+  @UseGuards(JwtUserGuard)
+  async deleteEvent(@Req() req, @Param('id', ParseIntPipe) id: number): Promise<ResponseDto<void>> {
+    try {
+      const userId = req.user?.id;
+      await this.eventService.deleteEvent(id, userId);
+      return new ResponseDto(null, 'Event deleted successfully');
+    } catch (error) {
+      if (error instanceof UnauthorizedException) {
+        throw error;
+      }
+      throw new InternalServerErrorException('Error deleting event')
     }
   }
 }

--- a/src/modules/event/repositories/event.repository.ts
+++ b/src/modules/event/repositories/event.repository.ts
@@ -45,4 +45,8 @@ export class EventRepository {
     const event = await Event.findByPk(eventId);
     await event.update(updateEventType);
   }
+
+  async deleteEvent(eventId: number): Promise<void> {
+    await Event.destroy({ where: { id: eventId } });
+  }
 }

--- a/src/modules/event/services/event.service.ts
+++ b/src/modules/event/services/event.service.ts
@@ -30,9 +30,21 @@ export class EventService {
     const eventUserId = (await event).userId;
 
     if (eventUserId != userId) {
-      throw new UnauthorizedException('Only users who created the event can update it');
+
+      throw new UnauthorizedException('Only the user who created the event can update it.');
     }
 
     await this.eventRepository.updateEvent(eventId, updateEventType);
+  }
+
+  async deleteEvent(eventId: number, userId: number): Promise<void> {
+    const event = this.eventRepository.getEvent(eventId);
+    const eventUserId = (await event).userId;
+
+    if (eventUserId != userId) {
+      throw new UnauthorizedException('Only the user who created the event can delete it.');
+    }
+
+    await this.eventRepository.deleteEvent(eventId);
   }
 }


### PR DESCRIPTION
- Added a new endpoint to delete events, ensuring only the creator can delete their events
- Implemented authorization checks in EventService to validate user ownership before deletion
- Updated EventController and EventRepository to support the delete event feature